### PR TITLE
Changing to a batch size of 150 so we don't loose logs

### DIFF
--- a/heroku_kinesis.sh
+++ b/heroku_kinesis.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-nc -lk -p 514 -e /bin/log-shuttle -logs-url $KINESIS_URL -max-line-length 32000 -batch-size 1 -input-format rfc5424 -kinesis-shards $KINESIS_SHARDS
+nc -lk -p 514 -e /bin/log-shuttle -logs-url $KINESIS_URL -max-line-length 32000 -batch-size 150 -input-format rfc5424 -kinesis-shards $KINESIS_SHARDS

--- a/heroku_kinesis.sh
+++ b/heroku_kinesis.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-nc -lk -p 514 -e /bin/log-shuttle -logs-url $KINESIS_URL -max-line-length 32000 -batch-size 498 -input-format rfc5424 -kinesis-shards $KINESIS_SHARDS
+nc -lk -p 514 -e /bin/log-shuttle -logs-url $KINESIS_URL -max-line-length 32000 -batch-size 1 -input-format rfc5424 -kinesis-shards $KINESIS_SHARDS


### PR DESCRIPTION
Based on this comment: https://github.com/heroku/log-shuttle/blob/v0.14.0/kinesis_formatter.go#L14

`Kinesis has a very small payload side, so recommend setting config.BatchSize in the 1-3 range so as to not loose logs because we go over the batch size.`

We keep our log lines to a max of 32KB. Kinesis has a record size limit of 1000KB and a batch limit of 5000KB:

5000/32 = 156.25

Rounded to 150 for the batch size.
